### PR TITLE
fix: SRID in transform

### DIFF
--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -966,9 +966,9 @@ describe('transform', () => {
       .select((eb) => stf(eb).transform('geoma', 1).as('alias'));
     const compiled = query.compile();
     expect(compiled.sql).toBe(
-      'select ST_Transform("geoma", $1) as "alias" from "test"',
+      'select ST_Transform("geoma", 1::int) as "alias" from "test"',
     );
-    expect(compiled.parameters).toStrictEqual([1]);
+    expect(compiled.parameters).toStrictEqual([]);
   });
 });
 

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -525,7 +525,10 @@ export function transform<DB, TB extends keyof DB>(
   return fnWithAdditionalParameters(
     eb,
     'ST_Transform',
-    [transformGeoJSON(eb, geom, optionsWithDefault), sql.val<number>(srid)],
+    [
+      transformGeoJSON(eb, geom, optionsWithDefault),
+      sql.raw(`${parseInt(`${srid}`)}::int`),
+    ],
     optionsWithDefault,
   );
 }


### PR DESCRIPTION
# Description
node-postgres drivers add quote to parameter causing it to be use as string instead of number.

Reference : https://github.com/K4ST0R/kysely-postgis/issues/4

# Fix
Add cast to the SRID parameter