### PR TITLE
fix: distanceSphere function

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ console.log(query6.sql, query6.parameters);
 - difference(geoa column | GeoJSON /_object, string_/, geob column | GeoJSON /_object, string_/), see [postgis documentation](https://postgis.net/docs/ST_Difference.html)
 - disjoint(geoa column | GeoJSON /_object, string_/, geob column | GeoJSON /_object, string_/), see [postgis documentation](https://postgis.net/docs/ST_Disjoint.html)
 - distance(geoa column | GeoJSON /_object, string_/, geob column | GeoJSON /_object, string_/), see [postgis documentation](https://postgis.net/docs/ST_Distance.html)
-- distanceSphere(geoa column | GeoJSON /_object, string_/, geob column | GeoJSON /_object, string_/), see [postgis documentation](https://postgis.net/docs/ST_Distance_Sphere.html)
+- distanceSphere(geoa column | GeoJSON /_object, string_/, geob column | GeoJSON /_object, string_/), see [postgis documentation](https://postgis.net/docs/ST_DistanceSphere.html)
 - equals(geoa column | GeoJSON /_object, string_/, geob column | GeoJSON /_object, string_/), see [postgis documentation](https://postgis.net/docs/ST_Equals.html)
 - expand(geoa column | GeoJSON /_object, string_/, unitsToExpand number), see [postgis documentation](https://postgis.net/docs/ST_Expand.html)
 - geomFromGeoJSON(GeoJSON /_object, string or column name_/), see [postgis documentation](https://postgis.net/docs/ST_GeomFromGeoJSON.html)

--- a/src/function.test.ts
+++ b/src/function.test.ts
@@ -749,7 +749,7 @@ describe('distanceSphere', () => {
       .select((eb) => stf(eb).distanceSphere('geoma', 'geomb').as('alias'));
     const compiled = query.compile();
     expect(compiled.sql).toBe(
-      'select ST_Distance_Sphere("geoma", "geomb") as "alias" from "test"',
+      'select ST_DistanceSphere("geoma", "geomb") as "alias" from "test"',
     );
   });
 });

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -267,7 +267,7 @@ export function distanceSphere<DB, TB extends keyof DB>(
 
   return fnWithAdditionalParameters<DB, TB, number>(
     eb,
-    'ST_Distance_Sphere',
+    'ST_DistanceSphere',
     [
       transformGeoJSON(eb, geomA, optionsWithDefault),
       transformGeoJSON(eb, geomB, optionsWithDefault),


### PR DESCRIPTION
According to documentation [here](https://postgis.net/docs/ST_DistanceSphere.html) function name is now `ST_DistanceSphere`.

> Changed: 2.2.0 In prior versions this used to be called ST_Distance_Sphere